### PR TITLE
Do not open missing files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ### Version 0.0.4 (TBD)
 
 - Fixed crash when changed file is a directory (filters them out).
+- Fixed crash when opening missing file (filters them out).
+- Split rspec into multiple files.
+- Added tests for linter with all variables set using Danger file.
+- Variables used in multiple tests are defined as constants in `spec_helper.rb`.
 
 ### Version 0.0.3 (2022-04-22)
 

--- a/lib/logging_lint/plugin.rb
+++ b/lib/logging_lint/plugin.rb
@@ -191,12 +191,12 @@ module Danger
     #
     def log_lint
       if log_functions.nil? || log_functions.size <= 0
-        self.fail("No log functions are defined. Please check your Danger file.")
+        self.fail("Logging lint: No log functions are defined. Please check your Danger file.")
         return
       end
 
       if line_variable_regex.nil? || line_variable_regex.size <= 0
-        message("At least one variable index must be defined (using default). Please check your Danger file.")
+        message("Logging lint: At least one variable index must be defined (using default). Please check your Danger file.")
       end
 
       target_files = (git.modified_files - git.deleted_files) + git.added_files
@@ -207,7 +207,7 @@ module Danger
       end
 
       if target_files.empty?
-        message("No files to check.")
+        message("Logging lint: No files to check.")
         return
       end
 

--- a/spec/logging_lint_no_run_spec.rb
+++ b/spec/logging_lint_no_run_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require File.expand_path("spec_helper", __dir__)
+
+#
+# Tests for situations when the linter does not run because of either configuration or there are no files to check.
+#
+
+module Danger
+  describe Danger::DangerLoggingLint do
+    #
+    # Defines linter, danger file and other variables used by the linter.
+    #
+    describe "with Dangerfile" do
+      before do
+        @dangerfile = testing_dangerfile
+        @logging_lint = @dangerfile.logging_lint
+
+        mock_variables(@logging_lint)
+      end
+
+      #
+      # Test for logging lines in cases when linter does not run (either by config or file settings).
+      #
+
+      it "Error is printed when log functions are not configured" do
+        allow(@logging_lint).to receive(:log_functions).and_return([])
+        @logging_lint.log_lint
+        expect(@dangerfile.status_report[:errors]).to eq(["Logging lint: No log functions are defined. Please check your Danger file."])
+      end
+
+      it "Error is printed when log variable regex is not configured" do
+        allow(@logging_lint).to receive(:line_variable_regex).and_return([])
+        @logging_lint.log_lint
+        expect(@dangerfile.status_report[:messages][0]).to eq("Logging lint: At least one variable index must be defined (using default). Please check your Danger file.")
+      end
+
+      it "Nothing is printed when there are no files to check" do
+        @logging_lint.log_lint
+        expect(@dangerfile.status_report[:errors]).to eq([])
+        expect(@dangerfile.status_report[:messages][0]).to eq("Logging lint: No files to check.")
+      end
+
+      it "Nothing is printed when there are only folders to check" do
+        allow(@logging_lint).to receive(:file_extensions).and_return([])
+        allow(@logging_lint.git).to receive(:modified_files).and_return(%W(#{DIR_NAME}))
+        @logging_lint.log_lint
+        expect(@dangerfile.status_report[:errors]).to eq([])
+      end
+
+      it "Nothing is printed when there are no files to check (filtered by extensions)" do
+        allow(@logging_lint.git).to receive(:modified_files).and_return(MODIFIED_FILES)
+        allow(@logging_lint).to receive(:file_extensions).and_return(%w(unknownExtension))
+        @logging_lint.log_lint
+        expect(@dangerfile.status_report[:errors]).to eq([])
+      end
+    end
+  end
+end

--- a/spec/logging_lint_spec.rb
+++ b/spec/logging_lint_spec.rb
@@ -8,11 +8,6 @@ module Danger
       expect(Danger::DangerLoggingLint.new(nil)).to be_a Danger::Plugin
     end
 
-    dir_name = File.dirname(__FILE__)
-    modified_files = %W(#{dir_name}/fixtures/ModifiedFile.kt #{dir_name}/fixtures/IgnoredModifiedFile.txt)
-    added_files = %W(#{dir_name}/fixtures/NewFile.kt)
-    warning_text = "Does this log comply with security rules?"
-
     #
     # Defines linter, danger file and other variables used by the linter.
     #
@@ -25,55 +20,27 @@ module Danger
         allow(@logging_lint.git).to receive(:added_files).and_return([])
         allow(@logging_lint.git).to receive(:modified_files).and_return([])
         allow(@logging_lint).to receive(:file_extensions).and_return(%w(kt))
-      end
-
-      #
-      # Test for logging lines in cases when linter does not run (either by config or file settings).
-      #
-
-      it "Error is printed when log functions are not configured" do
-        allow(@logging_lint).to receive(:log_functions).and_return([])
-        @logging_lint.log_lint
-        expect(@dangerfile.status_report[:errors]).to eq(["No log functions are defined. Please check your Danger file."])
-      end
-
-      it "Error is printed when log variable regex is not configured" do
-        allow(@logging_lint).to receive(:line_variable_regex).and_return([])
-        @logging_lint.log_lint
-        expect(@dangerfile.status_report[:messages][0]).to eq("At least one variable index must be defined (using default). Please check your Danger file.")
-      end
-
-      it "Nothing is printed when there are no files to check" do
-        @logging_lint.log_lint
-        expect(@dangerfile.status_report[:errors]).to eq([])
-      end
-
-      it "Nothing is printed when there are folders to check" do
-        allow(@logging_lint).to receive(:file_extensions).and_return([])
-        allow(@logging_lint.git).to receive(:modified_files).and_return(%W(#{dir_name}))
-        @logging_lint.log_lint
-        expect(@dangerfile.status_report[:errors]).to eq([])
-      end
-
-      it "Nothing is printed when there are no files to check (filtered by extensions)" do
-        allow(@logging_lint.git).to receive(:modified_files).and_return(modified_files)
-        allow(@logging_lint).to receive(:file_extensions).and_return(%w(unknownExtension))
-        @logging_lint.log_lint
-        expect(@dangerfile.status_report[:errors]).to eq([])
-      end
-
-      it "Nothing is printed when log levels are not present" do
-        allow(@logging_lint).to receive(:log_functions).and_return(%w(missingLogLevel))
-        @logging_lint.log_lint
-        expect(@dangerfile.status_report[:warnings]).to eq([])
+        allow(@logging_lint).to receive(:log_functions).and_call_original
+        allow(@logging_lint).to receive(:warning_text).and_call_original
+        allow(@logging_lint).to receive(:log_regex).and_call_original
+        allow(@logging_lint).to receive(:line_variable_regex).and_call_original
+        allow(@logging_lint).to receive(:line_remove_regex).and_call_original
       end
 
       #
       # Test for logging lines in cases when linter does run.
       #
 
+      it "Nothing is printed when log functions are not present in files" do
+        allow(@logging_lint.git).to receive(:modified_files).and_return(MODIFIED_FILES)
+        allow(@logging_lint.git).to receive(:added_files).and_return(ADDED_FILES)
+        allow(@logging_lint).to receive(:log_functions).and_return(%w(unknownLogLevel))
+        @logging_lint.log_lint
+        expect(@dangerfile.status_report[:warnings]).to eq([])
+      end
+
       it "Log with variables is warned for modified files (end line index)" do
-        allow(@logging_lint.git).to receive(:modified_files).and_return(modified_files)
+        allow(@logging_lint.git).to receive(:modified_files).and_return(MODIFIED_FILES)
         allow(@logging_lint).to receive(:line_index_position).and_return("end")
         @logging_lint.log_lint
         violation_lines = [63, 64, 73, 76, 88, 92, 97, 98, 101, 106, 107, 110]
@@ -81,7 +48,7 @@ module Danger
       end
 
       it "Log with variables is warned for modified files (start line index)" do
-        allow(@logging_lint.git).to receive(:modified_files).and_return(modified_files)
+        allow(@logging_lint.git).to receive(:modified_files).and_return(MODIFIED_FILES)
         allow(@logging_lint).to receive(:line_index_position).and_return("start")
         @logging_lint.log_lint
         violation_lines = [63, 64, 71, 74, 85, 89, 93, 98, 99, 102, 107, 108]
@@ -89,7 +56,7 @@ module Danger
       end
 
       it "Log with variables is warned for modified files (middle line index)" do
-        allow(@logging_lint.git).to receive(:modified_files).and_return(modified_files)
+        allow(@logging_lint.git).to receive(:modified_files).and_return(MODIFIED_FILES)
         allow(@logging_lint).to receive(:line_index_position).and_return("middle")
         @logging_lint.log_lint
         violation_lines = [63, 64, 73, 76, 88, 92, 97, 98, 101, 106, 107, 110]
@@ -97,28 +64,24 @@ module Danger
       end
 
       it "Log with variables is warned for new files" do
-        allow(@logging_lint.git).to receive(:added_files).and_return(added_files)
+        allow(@logging_lint.git).to receive(:added_files).and_return(ADDED_FILES)
         @logging_lint.log_lint
         violation_lines = [47, 48, 57, 60, 72, 76]
         compare_warning_with_lines(violation_lines)
       end
 
-      #
-      # Test for waning texts and links.
-      #
-
-      it "Log with variables is warned with link address" do
-        warning_link = "http://error.io"
-        allow(@logging_lint.git).to receive(:added_files).and_return(added_files)
-        allow(@logging_lint).to receive(:warning_description).and_return(warning_link)
+      it "Log with variables is warned for new files (with all params)" do
+        custom_warning_text = "Warning text"
+        allow(@logging_lint.git).to receive(:added_files).and_return(ADDED_FILES)
+        @logging_lint.log_functions = %w(logInfo)
+        @logging_lint.warning_text = custom_warning_text
+        @logging_lint.log_regex = '[ ]?[{(](?:\n?|.)["]?(?:\n?|.)["]?(?:\n?|.)+(?:[)}][ ]?\n)'
+        @logging_lint.line_variable_regex = ['[{(](\n| |\+)*([^\"]\w[^\"])+', '(\".*\$.*\")']
+        @logging_lint.line_remove_regex = ['(\+ )?\".*\"']
         @logging_lint.log_lint
-        expect(@dangerfile.status_report[:warnings][0]).to eq("#{warning_text} #{warning_link}")
-      end
-
-      it "Log with variables is warned without link address" do
-        allow(@logging_lint.git).to receive(:added_files).and_return(added_files)
-        @logging_lint.log_lint
-        expect(@dangerfile.status_report[:warnings][0]).to eq(warning_text)
+        violation_lines = [47, 48, 57, 60, 72, 76]
+        compare_warning_with_lines(violation_lines)
+        expect(@dangerfile.violation_report[:warnings][0].message).to eq(custom_warning_text)
       end
 
       #

--- a/spec/logging_lint_spec.rb
+++ b/spec/logging_lint_spec.rb
@@ -63,6 +63,13 @@ module Danger
         compare_warning_with_lines(violation_lines)
       end
 
+      it "Log with variables is warned for modified files without crashing due to missing files" do
+        allow(@logging_lint.git).to receive(:modified_files).and_return(MODIFIED_FILES + %W(#{DIR_NAME}/fixtures/MissingFile.kt))
+        @logging_lint.log_lint
+        violation_lines = [63, 64, 73, 76, 88, 92, 97, 98, 101, 106, 107, 110]
+        compare_warning_with_lines(violation_lines)
+      end
+
       it "Log with variables is warned for new files" do
         allow(@logging_lint.git).to receive(:added_files).and_return(ADDED_FILES)
         @logging_lint.log_lint

--- a/spec/logging_lint_text_spec.rb
+++ b/spec/logging_lint_text_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require File.expand_path("spec_helper", __dir__)
+
+#
+# Tests for warning text creation. Text can contain description which can be defined in Danger file.
+#
+
+module Danger
+  describe Danger::DangerLoggingLint do
+    #
+    # Defines linter, danger file and other variables used by the linter.
+    #
+    describe "with Dangerfile" do
+      before do
+        @dangerfile = testing_dangerfile
+        @logging_lint = @dangerfile.logging_lint
+
+        mock_variables(@logging_lint)
+      end
+
+      #
+      # Test for waning text and description (optional).
+      #
+
+      it "Log with variables is warned description (link address)" do
+        warning_description = "http://error.io"
+        allow(@logging_lint.git).to receive(:added_files).and_return(ADDED_FILES)
+        allow(@logging_lint).to receive(:warning_description).and_return(warning_description)
+        @logging_lint.log_lint
+        expect(@dangerfile.status_report[:warnings][0]).to eq("#{WARNING_TEXT} #{warning_description}")
+      end
+
+      it "Log with variables is warned without warning description" do
+        allow(@logging_lint.git).to receive(:added_files).and_return(ADDED_FILES)
+        @logging_lint.log_lint
+        expect(@dangerfile.status_report[:warnings][0]).to eq(WARNING_TEXT)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,3 +71,22 @@ def testing_dangerfile
   env = Danger::EnvironmentManager.new(testing_env)
   Danger::Dangerfile.new(env, testing_ui)
 end
+
+# Mocks linter variables. Should be called in "before" block.
+def mock_variables(logging_lint)
+  allow(logging_lint.git).to receive(:deleted_files).and_return([])
+  allow(logging_lint.git).to receive(:added_files).and_return([])
+  allow(logging_lint.git).to receive(:modified_files).and_return([])
+  allow(logging_lint).to receive(:file_extensions).and_return(%w(kt))
+  allow(logging_lint).to receive(:log_functions).and_call_original
+  allow(logging_lint).to receive(:warning_text).and_call_original
+  allow(logging_lint).to receive(:log_regex).and_call_original
+  allow(logging_lint).to receive(:line_variable_regex).and_call_original
+  allow(logging_lint).to receive(:line_remove_regex).and_call_original
+end
+
+# Defines test variables used in multiple text files.
+DIR_NAME = File.dirname(__FILE__)
+MODIFIED_FILES = %W(#{DIR_NAME}/fixtures/ModifiedFile.kt #{DIR_NAME}/fixtures/IgnoredModifiedFile.txt).freeze
+ADDED_FILES = %W(#{DIR_NAME}/fixtures/NewFile.kt).freeze
+WARNING_TEXT = "Does this log comply with security rules?"


### PR DESCRIPTION
- Fixed crash when opening missing file (filters them out).
- Split rspec into multiple files.
- Added tests for linter with all variables set using Danger file.
- Variables used in multiple tests are defined as constants in `spec_helper.rb`.